### PR TITLE
Improve radio entropy mixing safety

### DIFF
--- a/src/mesh/HardwareRNG.cpp
+++ b/src/mesh/HardwareRNG.cpp
@@ -1,0 +1,158 @@
+#include "HardwareRNG.h"
+
+#include <algorithm>
+#include <cstring>
+#include <random>
+
+#include "configuration.h"
+
+#if HAS_RADIO
+#include "RadioLibInterface.h"
+#endif
+
+#if defined(ARCH_NRF52)
+#include <Adafruit_nRFCrypto.h>
+extern Adafruit_nRFCrypto nRFCrypto;
+#elif defined(ARCH_ESP32)
+#include <esp_system.h>
+#elif defined(ARCH_RP2040)
+#include <Arduino.h>
+#elif defined(ARCH_PORTDUINO)
+#include <random>
+#include <sys/random.h>
+#include <unistd.h>
+#endif
+
+namespace HardwareRNG
+{
+
+namespace
+{
+void fillWithRandomDevice(uint8_t *buffer, size_t length)
+{
+    std::random_device rd;
+    size_t offset = 0;
+    while (offset < length) {
+        uint32_t value = rd();
+        size_t toCopy = std::min(length - offset, sizeof(value));
+        memcpy(buffer + offset, &value, toCopy);
+        offset += toCopy;
+    }
+}
+
+#if HAS_RADIO
+bool mixWithLoRaEntropy(uint8_t *buffer, size_t length)
+{
+    // Only attempt to pull entropy from the modem if it is initialized and exposes the helper.
+    // When the radio stack is disabled or has not yet been configured, we simply skip this step
+    // and return false so callers know no extra mixing occurred.
+    RadioLibInterface *radio = RadioLibInterface::instance;
+    if (!radio) {
+        return false;
+    }
+
+    constexpr size_t chunkSize = 16;
+    uint8_t scratch[chunkSize];
+    size_t offset = 0;
+    bool mixed = false;
+
+    while (offset < length) {
+        size_t toCopy = std::min(length - offset, chunkSize);
+
+        // randomBytes() returns false if the modem does not support it or is not ready
+        // (for instance, when the radio is powered down). We break immediately to avoid
+        // blocking or returning partially-filled entropy and simply report failure.
+        if (!radio->randomBytes(scratch, toCopy)) {
+            break;
+        }
+
+        for (size_t i = 0; i < toCopy; ++i) {
+            buffer[offset + i] ^= scratch[i];
+        }
+
+        mixed = true;
+        offset += toCopy;
+    }
+
+    // Avoid leaving the modem-sourced bytes sitting on the stack longer than needed.
+    if (mixed) {
+        memset(scratch, 0, sizeof(scratch));
+    }
+
+    return mixed;
+}
+#endif
+} // namespace
+
+bool fill(uint8_t *buffer, size_t length)
+{
+    if (!buffer || length == 0) {
+        return false;
+    }
+
+    bool filled = false;
+
+#if defined(ARCH_NRF52)
+    // The Nordic SDK RNG provides cryptographic-quality randomness backed by hardware.
+    nRFCrypto.begin();
+    auto result = nRFCrypto.Random.generate(buffer, length);
+    nRFCrypto.end();
+    filled = result;
+#elif defined(ARCH_ESP32)
+    // ESP32 exposes a true RNG via esp_fill_random().
+    esp_fill_random(buffer, length);
+    filled = true;
+#elif defined(ARCH_RP2040)
+    // RP2040 has a hardware random number generator accessible through the Arduino core.
+    size_t offset = 0;
+    while (offset < length) {
+        uint32_t value = rp2040.hwrand32();
+        size_t toCopy = std::min(length - offset, sizeof(value));
+        memcpy(buffer + offset, &value, toCopy);
+        offset += toCopy;
+    }
+    filled = true;
+#elif defined(ARCH_PORTDUINO)
+    // Prefer the host OS RNG first when running under Portduino.
+    ssize_t generated = ::getrandom(buffer, length, 0);
+    if (generated == static_cast<ssize_t>(length)) {
+        filled = true;
+    }
+
+    if (!filled) {
+        fillWithRandomDevice(buffer, length);
+        filled = true;
+    }
+#else
+    fillWithRandomDevice(buffer, length);
+    filled = true;
+#endif
+
+    if (!filled) {
+        // As a last resort, fall back to std::random_device. This should only be reached
+        // if a platform-specific source was unavailable.
+        fillWithRandomDevice(buffer, length);
+        filled = true;
+    }
+
+#if HAS_RADIO
+    // Best-effort: if the radio is active and can provide modem entropy, XOR it over the
+    // buffer to improve overall quality. We ignore failures to keep RNG usable even when
+    // radio hardware is powered down or uninitialized.
+    filled = mixWithLoRaEntropy(buffer, length) || filled;
+#endif
+
+    return filled;
+}
+
+bool seed(uint32_t &seedOut)
+{
+    uint32_t candidate = 0;
+    if (!fill(reinterpret_cast<uint8_t *>(&candidate), sizeof(candidate))) {
+        return false;
+    }
+    seedOut = candidate;
+    return true;
+}
+
+} // namespace HardwareRNG

--- a/src/mesh/HardwareRNG.h
+++ b/src/mesh/HardwareRNG.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace HardwareRNG
+{
+
+/**
+ * Fill the provided buffer with random bytes sourced from the most
+ * appropriate hardware-backed RNG available on the current platform.
+ *
+ * @param buffer Destination buffer for random bytes
+ * @param length Number of bytes to write
+ * @return true if the buffer was fully populated with entropy, false on failure
+ */
+bool fill(uint8_t *buffer, size_t length);
+
+/**
+ * Populate a 32-bit seed value with hardware-backed randomness where possible.
+ *
+ * @param seedOut Destination for the generated seed value
+ * @return true if a seed was produced from a reliable entropy source
+ */
+bool seed(uint32_t &seedOut);
+
+} // namespace HardwareRNG

--- a/src/mesh/RadioLibInterface.cpp
+++ b/src/mesh/RadioLibInterface.cpp
@@ -246,6 +246,15 @@ bool RadioLibInterface::findInTxQueue(NodeNum from, PacketId id)
     return txQueue.find(from, id);
 }
 
+bool RadioLibInterface::randomBytes(uint8_t *buffer, size_t length)
+{
+    if (!buffer || length == 0 || !iface) {
+        return false;
+    }
+
+    return iface->random(buffer, length) == RADIOLIB_ERR_NONE;
+}
+
 /** radio helper thread callback.
 We never immediately transmit after any operation (either Rx or Tx). Instead we should wait a random multiple of
 'slotTimes' (see definition in RadioInterface.h) taken from a contention window (CW) to lower the chance of collision.

--- a/src/mesh/RadioLibInterface.h
+++ b/src/mesh/RadioLibInterface.h
@@ -158,6 +158,12 @@ class RadioLibInterface : public RadioInterface, protected concurrency::Notified
     /** Attempt to find a packet in the TxQueue. Returns true if the packet was found. */
     virtual bool findInTxQueue(NodeNum from, PacketId id) override;
 
+    /**
+     * Request randomness sourced from the LoRa modem, if supported by the active RadioLib interface.
+     * @return true if len bytes were produced, false otherwise.
+     */
+    bool randomBytes(uint8_t *buffer, size_t length);
+
   private:
     /** if we have something waiting to send, start a short (random) timer so we can come check for collision before actually
      * doing the transmit */

--- a/src/platform/portduino/PortduinoGlue.cpp
+++ b/src/platform/portduino/PortduinoGlue.cpp
@@ -1,6 +1,7 @@
 #include "CryptoEngine.h"
 #include "PortduinoGPIO.h"
 #include "SPIChip.h"
+#include "HardwareRNG.h"
 #include "mesh/RF95Interface.h"
 #include "sleep.h"
 #include "target_specific.h"
@@ -225,7 +226,9 @@ void portduinoSetup()
         std::cout << "Running in simulated mode." << std::endl;
         portduino_config.MaxNodes = 200; // Default to 200 nodes
         // Set the random seed equal to TCPPort to have a different seed per instance
-        randomSeed(TCPPort);
+        uint32_t seed = TCPPort;
+        HardwareRNG::seed(seed);
+        randomSeed(seed);
         return;
     }
 
@@ -433,7 +436,9 @@ void portduinoSetup()
     }
     printf("MAC ADDRESS: %02X:%02X:%02X:%02X:%02X:%02X\n", dmac[0], dmac[1], dmac[2], dmac[3], dmac[4], dmac[5]);
     // Rather important to set this, if not running simulated.
-    randomSeed(time(NULL));
+    uint32_t seed = static_cast<uint32_t>(time(NULL));
+    HardwareRNG::seed(seed);
+    randomSeed(seed);
 
     std::string defaultGpioChipName = gpioChipName + std::to_string(portduino_config.lora_default_gpiochip);
     for (auto i : portduino_config.all_pins) {

--- a/src/platform/rp2xx0/main-rp2xx0.cpp
+++ b/src/platform/rp2xx0/main-rp2xx0.cpp
@@ -1,3 +1,4 @@
+#include "HardwareRNG.h"
 #include "configuration.h"
 #include "hardware/xosc.h"
 #include <hardware/clocks.h>
@@ -98,10 +99,10 @@ void getMacAddr(uint8_t *dmac)
 
 void rp2040Setup()
 {
-    /* Sets a random seed to make sure we get different random numbers on each boot.
-       Taken from CPU cycle counter and ROSC oscillator, so should be pretty random.
-    */
-    randomSeed(rp2040.hwrand32());
+    /* Sets a random seed to make sure we get different random numbers on each boot. */
+    uint32_t seed = rp2040.hwrand32();
+    HardwareRNG::seed(seed);
+    randomSeed(seed);
 
 #ifdef RP2040_SLOW_CLOCK
     uint f_pll_sys = frequency_count_khz(CLOCKS_FC0_SRC_VALUE_PLL_SYS_CLKSRC_PRIMARY);


### PR DESCRIPTION
## Summary
- add safety comments and guard rails around LoRa entropy mixing so RNG stays usable when the radio is inactive
- document platform RNG choices for readability
- clear modem-derived scratch data after successful mixing to reduce lifetime of entropy bytes

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a15853e6483249f487dcf06729e59)